### PR TITLE
Added a workflow_dispatch Event for Manual Workflow Triggers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
 jobs:
   push-extension:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a `workflow_dispatch` trigger to the workflow file in order to allow the GitHub Action to be triggered manually.