### PR TITLE
Fixed Workflow for Updating MindsDB Version

### DIFF
--- a/.github/workflows/bump-mindsdb-version.yml
+++ b/.github/workflows/bump-mindsdb-version.yml
@@ -4,12 +4,6 @@ on:
   repository_dispatch:
     types: [completed]
 
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to bump to"
-        required: true
-
 jobs:
   bump-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump-mindsdb-version.yml
+++ b/.github/workflows/bump-mindsdb-version.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Debug event
-        run: echo ${{ toJson(github.event) }} # Output the entire event payload for debugging
+        run: echo "${{ toJson(github.event) }}"
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
This PR,
- Removes the workflow_dispatch event
- Updates the data that is printed for de-bugging